### PR TITLE
Converting BasicEngine API to TFLite API

### DIFF
--- a/install_requirements.sh
+++ b/install_requirements.sh
@@ -16,7 +16,7 @@ sudo apt-get install -y python3 python3-pyaudio python3-numpy python3-scipy
 
 sudo apt-get install -y python3-dev libsdl-image1.2-dev libsdl-mixer1.2-dev libsdl-ttf2.0-dev   libsdl1.2-dev libsmpeg-dev python-numpy subversion libportmidi-dev ffmpeg libswscale-dev libavformat-dev libavcodec-dev  libfreetype6-dev
 
-sudo apt.get install -y python3-pyaudio
+sudo apt-get install -y python3-pyaudio
 
 pip3 install pygame
 

--- a/model.py
+++ b/model.py
@@ -169,15 +169,8 @@ def read_commands(filename):
 
 
 def get_output(interpreter):
-    """Returns no more than top_k categories with score >= score_threshold."""
-    scores = common.output_tensor(interpreter, 0)
-    print(scores)
-#    categories = [
-#        Category(i, scores[i])
-#        for i in np.argpartition(scores, -top_k)[-top_k:]
-#        if scores[i] >= score_threshold
-#    ]
-#    return sorted(categories, key=operator.itemgetter(1), reverse=True)
+    """Returns entire output, threshold is applied later."""
+    return output_tensor(interpreter, 0)
 
 def output_tensor(interpreter, i):
     """Returns dequantized output tensor if quantized before."""
@@ -233,7 +226,7 @@ def add_model_flags(parser):
       "However you may alternative sampling rate that may or may not work."
       "If you specify 48000 it will be downsampled to 16000.")
 
-def classify_audio(audio_device_index, engine, interpreter, labels_file,
+def classify_audio(audio_device_index, interpreter, labels_file,
                    commands_file=None,
                    result_callback=None, dectection_callback=None,
                    sample_rate_hz=16000,
@@ -263,11 +256,9 @@ def classify_audio(audio_device_index, engine, interpreter, labels_file,
     last_detection = -1
     while not timed_out:
       spectrogram = feature_extractor.get_next_spectrogram(recorder)
-      print(spectrogram.flatten())
       set_input(interpreter, spectrogram.flatten())
       interpreter.invoke()
       result = get_output(interpreter)
-      _, result = engine.RunInference(spectrogram.flatten())
       if result_callback:
         result_callback(result, commands, labels)
       if dectection_callback:

--- a/run_hearing_snake.py
+++ b/run_hearing_snake.py
@@ -22,7 +22,6 @@ import os
 from random import randint
 from threading import Thread
 import time
-from edgetpu.basic.basic_engine import BasicEngine
 import model
 import pygame
 from pygame.locals import *
@@ -487,10 +486,11 @@ class App:
     pygame.quit()
 
   def spotter(self, args):
-    engine = BasicEngine(args.model_file)
+    interpreter = model.make_interpreter(args.model_file)
+    interpreter.allocate_tensors()
 
     mic = args.mic if args.mic is None else int(args.mic)
-    model.classify_audio(mic, engine,
+    model.classify_audio(mic, interpreter,
                          labels_file="config/labels_gc2.raw.txt",
                          commands_file="config/commands_v2_snake.txt",
                          dectection_callback=self._controler.callback,

--- a/run_model.py
+++ b/run_model.py
@@ -23,7 +23,6 @@ from __future__ import print_function
 
 import argparse
 import sys
-from edgetpu.basic.basic_engine import BasicEngine
 import model
 import numpy as np
 
@@ -51,9 +50,8 @@ def main():
   args = parser.parse_args()
   interpreter = model.make_interpreter(args.model_file)
   interpreter.allocate_tensors()
-  engine = BasicEngine(args.model_file)
   mic = args.mic if args.mic is None else int(args.mic)
-  model.classify_audio(mic, engine, interpreter,
+  model.classify_audio(mic, interpreter,
                        labels_file="config/labels_gc2.raw.txt",
                        result_callback=print_results,
                        sample_rate_hz=int(args.sample_rate_hz),

--- a/run_model.py
+++ b/run_model.py
@@ -49,9 +49,11 @@ def main():
   parser = argparse.ArgumentParser()
   model.add_model_flags(parser)
   args = parser.parse_args()
+  interpreter = model.make_interpreter(args.model_file)
+  interpreter.allocate_tensors()
   engine = BasicEngine(args.model_file)
   mic = args.mic if args.mic is None else int(args.mic)
-  model.classify_audio(mic, engine,
+  model.classify_audio(mic, engine, interpreter,
                        labels_file="config/labels_gc2.raw.txt",
                        result_callback=print_results,
                        sample_rate_hz=int(args.sample_rate_hz),

--- a/run_yt_voice_control.py
+++ b/run_yt_voice_control.py
@@ -27,7 +27,6 @@ from __future__ import print_function
 
 import argparse
 import sys
-from edgetpu.basic.basic_engine import BasicEngine
 import model
 from pykeyboard import PyKeyboard
 
@@ -70,7 +69,8 @@ def main():
   parser = argparse.ArgumentParser()
   model.add_model_flags(parser)
   args = parser.parse_args()
-  engine = BasicEngine(args.model_file)
+  interpreter = model.make_interpreter(args.model_file)
+  interpreter.allocate_tensors()
   mic = args.mic if args.mic is None else int(args.mic)
   yt_control = YoutubeControl()
   sys.stdout.write("--------------------\n")
@@ -78,7 +78,7 @@ def main():
   sys.stdout.write("Just ensure that focus is on the YouTube player.\n")
   sys.stdout.write("--------------------\n")
 
-  model.classify_audio(mic, engine,
+  model.classify_audio(mic, interpreter,
                        labels_file="config/labels_gc2.raw.txt",
                        commands_file="config/commands_v2.txt",
                        dectection_callback=yt_control.run_command,


### PR DESCRIPTION
Updating this example to use the TFLite API instead of the EdgeTPU Basic Engine API.

Also incorporates typo fix from [this PR](https://github.com/google-coral/project-keyword-spotter/pull/2).

The get_output, output_tensor, input_tensor, set_input, and make_interpreter functions are all based on [this TFLite classification example](https://github.com/google-coral/tflite/blob/master/python/examples/classification/classify_image.py) whose functions are defined [here](https://github.com/google-coral/tflite/blob/master/python/examples/classification/classify.py). This is very similar to the TFLite conversion for the [camera examples](https://github.com/google-coral/examples-camera/pull/24).

Tested: Able to run run_model, run_snake, and run_yt_voice_control with the Coral Dev Board, Raspberry Pi + Accelerator, and Linux Machine + Accelerator. The behavior of the TFLite examples matches the behavior of the code using the old API. 