### PR TITLE
properly load the libedgetpu dylib based on the OS

### DIFF
--- a/model.py
+++ b/model.py
@@ -24,8 +24,14 @@ import mel_features
 import numpy as np
 import queue
 import tflite_runtime.interpreter as tflite
+import platform
 
-EDGETPU_SHARED_LIB = 'libedgetpu.so.1'
+EDGETPU_SHARED_LIB = {
+    'Linux': 'libedgetpu.so.1',
+    'Darwin': 'libedgetpu.1.dylib',
+    'Windows': 'edgetpu.dll'
+}[platform.system()]
+
 q = queue.Queue()
 
 logging.basicConfig(


### PR DESCRIPTION
Now that the edge TPU runs on Mac and Windows, we need to pick the right version of the dylib to load. Note that other linux expectations are preventing this demo from running smoothly, but this is the key blocker.